### PR TITLE
Rename GFMDiagrams to gfmd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="GFMDiagrams",
+    name="gfmdiagrams",
     version="0.2.0",
     url="https://github.com/cookpad/gfm-diagram",
     author="Ben Howes",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="gfmdiagrams",
+    name="gfmd",
     version="0.2.0",
     url="https://github.com/cookpad/gfm-diagram",
     author="Ben Howes",


### PR DESCRIPTION
What this PR does:
- Renames **GFMDiagrams** to **gfmd** in `setup.py`. This fixes the `different name in metadata: 'GFMDiagrams'` error encountered during `pipenv sync`.